### PR TITLE
ALS-4770: Add site code to query ID

### DIFF
--- a/ui/src/main/webapp/picsureui/overrides/package-data-view.js
+++ b/ui/src/main/webapp/picsureui/overrides/package-data-view.js
@@ -126,7 +126,9 @@ define(['jquery',
             $('#copy-query-ids-btn').on('click', function(){
                 let queryIds = [];
                 $('#queryIds').find('input[type="checkbox"]:checked').each(function(){
-                    queryIds.push($(this).parent().find('input[type="text"]').val());
+                    let siteCode = $(this).parent().find(".resource-name").text();
+                    let queryId = $(this).parent().find('input[type="text"]').val();
+                    queryIds.push(siteCode + ": " + queryId);
                 });
                 let queryIdsString = queryIds.join(',');
                 navigator.clipboard.writeText(queryIdsString);


### PR DESCRIPTION
When a user copies their query IDs for use on the RedCAP form, those IDs should be site code: ID pairs.